### PR TITLE
Ignore non-GET/POST requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,8 +77,7 @@
     "@types/graphql": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.9.4.tgz",
-      "integrity": "sha512-ob2dps4itT/Le5DbxjssBXtBnloDIRUbkgtAvaB42mJ8pVIWMRuURD9WjnhaEGZ4Ql/EryXMQWeU8Y0EU73QLw==",
-      "dev": true
+      "integrity": "sha512-ob2dps4itT/Le5DbxjssBXtBnloDIRUbkgtAvaB42mJ8pVIWMRuURD9WjnhaEGZ4Ql/EryXMQWeU8Y0EU73QLw=="
     },
     "@types/hapi": {
       "version": "16.1.9",
@@ -226,7 +225,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-      "dev": true,
       "requires": {
         "mime-types": "2.1.16",
         "negotiator": "0.6.1"
@@ -268,6 +266,11 @@
         }
       }
     },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+    },
     "apollo-engine-binary-darwin": {
       "version": "0.2017.9-112-gedf90fef",
       "resolved": "https://registry.npmjs.org/apollo-engine-binary-darwin/-/apollo-engine-binary-darwin-0.2017.9-112-gedf90fef.tgz",
@@ -290,7 +293,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-1.1.0.tgz",
       "integrity": "sha1-dMO/Q5ThTq56tgsdmZo8W4qpTpo=",
-      "dev": true,
       "requires": {
         "apollo-tracing": "0.0.7"
       }
@@ -333,17 +335,24 @@
         }
       }
     },
+    "apollo-server-koa": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-koa/-/apollo-server-koa-1.1.2.tgz",
+      "integrity": "sha1-n+5oJx9us9RIp1C+tDszCRHyQM8=",
+      "requires": {
+        "apollo-server-core": "1.1.0",
+        "apollo-server-module-graphiql": "1.1.2"
+      }
+    },
     "apollo-server-module-graphiql": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/apollo-server-module-graphiql/-/apollo-server-module-graphiql-1.1.2.tgz",
-      "integrity": "sha1-SaFUz4DphKywgr0AlhdbVh4b+8w=",
-      "dev": true
+      "integrity": "sha1-SaFUz4DphKywgr0AlhdbVh4b+8w="
     },
     "apollo-tracing": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.0.7.tgz",
       "integrity": "sha512-jvjNmOOb3M2QiBEuz9Vjp6HiXtZuDwRvHxqBZQ+TE0UoODRnJoQu5LF1uvPI2ooOHiPC1ce4SAKNNIU9y02EeA==",
-      "dev": true,
       "requires": {
         "graphql-tools": "1.2.2"
       }
@@ -470,8 +479,7 @@
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
-      "dev": true
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "call": {
       "version": "4.0.2",
@@ -575,6 +583,17 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
+    "co-body": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/co-body/-/co-body-5.1.1.tgz",
+      "integrity": "sha1-2XeB0eM0S6SoIP0YBr3fg0FQUjY=",
+      "requires": {
+        "inflation": "2.0.0",
+        "qs": "6.5.0",
+        "raw-body": "2.3.2",
+        "type-is": "1.6.15"
+      }
+    },
     "combined-stream": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
@@ -627,14 +646,12 @@
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-      "dev": true
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
-      "dev": true
+      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
     },
     "cookie": {
       "version": "0.3.1",
@@ -647,6 +664,20 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
       "dev": true
+    },
+    "cookies": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.1.tgz",
+      "integrity": "sha1-fIphX1SBxhq58WyDNzG8uPZjuZs=",
+      "requires": {
+        "depd": "1.1.1",
+        "keygrip": "1.0.2"
+      }
+    },
+    "copy-to": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/copy-to/-/copy-to-2.0.1.tgz",
+      "integrity": "sha1-JoD7uAaKSNCGVrYJgJK9r8kG9KU="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -680,7 +711,6 @@
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -694,28 +724,35 @@
         "type-detect": "4.0.3"
       }
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+    },
     "depd": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-      "dev": true
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
     },
     "deprecated-decorator": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
-      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=",
-      "dev": true
+      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc="
     },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-      "dev": true
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "diff": {
       "version": "3.2.0",
@@ -735,8 +772,7 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "encodeurl": {
       "version": "1.0.1",
@@ -744,11 +780,15 @@
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
       "dev": true
     },
+    "error-inject": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz",
+      "integrity": "sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc="
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -847,8 +887,7 @@
     "fresh": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
-      "dev": true
+      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -910,7 +949,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-1.2.2.tgz",
       "integrity": "sha512-FBcpceJMOYq8PEI8c40S5vAiCtwWh9vSrJc4DoanAiQOLC8DOXaZ8nY+3+/AwHRur+R+zDprGoL14QqcWr0RrA==",
-      "dev": true,
       "requires": {
         "@types/graphql": "0.9.4",
         "deprecated-decorator": "0.1.6",
@@ -1045,11 +1083,19 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
+    "http-assert": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.3.0.tgz",
+      "integrity": "sha1-oxpc+IyHPsu1eWkH1NbxMujAHko=",
+      "requires": {
+        "deep-equal": "1.0.1",
+        "http-errors": "1.6.2"
+      }
+    },
     "http-errors": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
       "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-      "dev": true,
       "requires": {
         "depd": "1.1.1",
         "inherits": "2.0.3",
@@ -1070,8 +1116,12 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-      "dev": true
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+    },
+    "inflation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.0.0.tgz",
+      "integrity": "sha1-i0F+R8KPklpFEz2RTKH9OJEH8w8="
     },
     "inflight": {
       "version": "1.0.6",
@@ -1086,8 +1136,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ipaddr.js": {
       "version": "1.4.0",
@@ -1132,10 +1181,20 @@
         }
       }
     },
+    "is-generator-function": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.6.tgz",
+      "integrity": "sha1-nnFlPNFf/zQcecQVFGChMdMen8Q="
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "isemail": {
       "version": "2.2.1",
@@ -1233,6 +1292,116 @@
         }
       }
     },
+    "keygrip": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.2.tgz",
+      "integrity": "sha1-rTKXxVcGneqLz+ek+kkbdcXd65E="
+    },
+    "koa": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.3.0.tgz",
+      "integrity": "sha1-nh6OTaQBg5xXuFJ+rcV/dhJ1Vac=",
+      "requires": {
+        "accepts": "1.3.3",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.2",
+        "cookies": "0.7.1",
+        "debug": "2.6.8",
+        "delegates": "1.0.0",
+        "depd": "1.1.1",
+        "destroy": "1.0.4",
+        "error-inject": "1.0.0",
+        "escape-html": "1.0.3",
+        "fresh": "0.5.0",
+        "http-assert": "1.3.0",
+        "http-errors": "1.6.2",
+        "is-generator-function": "1.0.6",
+        "koa-compose": "4.0.0",
+        "koa-convert": "1.2.0",
+        "koa-is-json": "1.0.0",
+        "mime-types": "2.1.16",
+        "on-finished": "2.3.0",
+        "only": "0.0.2",
+        "parseurl": "1.3.1",
+        "statuses": "1.3.1",
+        "type-is": "1.6.15",
+        "vary": "1.1.1"
+      }
+    },
+    "koa-bodyparser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/koa-bodyparser/-/koa-bodyparser-4.2.0.tgz",
+      "integrity": "sha1-vObgi8Zfhwm20fqpQRx/DYk4qlQ=",
+      "requires": {
+        "co-body": "5.1.1",
+        "copy-to": "2.0.1"
+      }
+    },
+    "koa-compose": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.0.0.tgz",
+      "integrity": "sha1-KAClE9nDYe8NY4UrA45Pby1adzw="
+    },
+    "koa-convert": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-1.2.0.tgz",
+      "integrity": "sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=",
+      "requires": {
+        "co": "4.6.0",
+        "koa-compose": "3.2.1"
+      },
+      "dependencies": {
+        "koa-compose": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
+          "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
+          "requires": {
+            "any-promise": "1.3.0"
+          }
+        }
+      }
+    },
+    "koa-is-json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz",
+      "integrity": "sha1-JzwH7c3Ljfaiwat9We52SRRR7BQ="
+    },
+    "koa-router": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-7.2.1.tgz",
+      "integrity": "sha1-tApKs8attLQIld69AKnGQDBOMDk=",
+      "requires": {
+        "debug": "2.6.8",
+        "http-errors": "1.6.2",
+        "koa-compose": "3.2.1",
+        "methods": "1.1.2",
+        "path-to-regexp": "1.7.0"
+      },
+      "dependencies": {
+        "koa-compose": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
+          "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
+          "requires": {
+            "any-promise": "1.3.0"
+          }
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
+    },
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
@@ -1304,8 +1473,7 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-      "dev": true
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -1316,8 +1484,7 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "mime": {
       "version": "1.3.4",
@@ -1403,14 +1570,12 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
-      "dev": true
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "nigel": {
       "version": "2.0.2",
@@ -1439,7 +1604,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "dev": true,
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -1453,11 +1617,15 @@
         "wrappy": "1.0.2"
       }
     },
+    "only": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
+      "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q="
+    },
     "parseurl": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
-      "dev": true
+      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1561,7 +1729,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
       "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
-      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "http-errors": "1.6.2",
@@ -1596,6 +1763,37 @@
         "tough-cookie": "2.3.2",
         "tunnel-agent": "0.6.0",
         "uuid": "3.1.0"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
+    "request-promise-native": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+      "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+      "dev": true,
+      "requires": {
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.3"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+          "dev": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        }
       }
     },
     "safe-buffer": {
@@ -1639,8 +1837,7 @@
     "setprototypeof": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-      "dev": true
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
     },
     "shot": {
       "version": "3.4.2",
@@ -1733,7 +1930,12 @@
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
     "stream-line-wrapper": {
@@ -1837,7 +2039,6 @@
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "dev": true,
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "2.1.16"
@@ -1852,8 +2053,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "dev": true
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "utils-merge": {
       "version": "1.0.0",
@@ -1869,8 +2069,7 @@
     "vary": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
-      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
-      "dev": true
+      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
     },
     "verror": {
       "version": "1.10.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,8 @@
     "@types/graphql": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-0.9.4.tgz",
-      "integrity": "sha512-ob2dps4itT/Le5DbxjssBXtBnloDIRUbkgtAvaB42mJ8pVIWMRuURD9WjnhaEGZ4Ql/EryXMQWeU8Y0EU73QLw=="
+      "integrity": "sha512-ob2dps4itT/Le5DbxjssBXtBnloDIRUbkgtAvaB42mJ8pVIWMRuURD9WjnhaEGZ4Ql/EryXMQWeU8Y0EU73QLw==",
+      "dev": true
     },
     "@types/hapi": {
       "version": "16.1.9",
@@ -225,6 +226,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+      "dev": true,
       "requires": {
         "mime-types": "2.1.16",
         "negotiator": "0.6.1"
@@ -269,7 +271,8 @@
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+      "dev": true
     },
     "apollo-engine-binary-darwin": {
       "version": "0.2017.9-112-gedf90fef",
@@ -293,6 +296,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-1.1.0.tgz",
       "integrity": "sha1-dMO/Q5ThTq56tgsdmZo8W4qpTpo=",
+      "dev": true,
       "requires": {
         "apollo-tracing": "0.0.7"
       }
@@ -339,6 +343,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/apollo-server-koa/-/apollo-server-koa-1.1.2.tgz",
       "integrity": "sha1-n+5oJx9us9RIp1C+tDszCRHyQM8=",
+      "dev": true,
       "requires": {
         "apollo-server-core": "1.1.0",
         "apollo-server-module-graphiql": "1.1.2"
@@ -347,12 +352,14 @@
     "apollo-server-module-graphiql": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/apollo-server-module-graphiql/-/apollo-server-module-graphiql-1.1.2.tgz",
-      "integrity": "sha1-SaFUz4DphKywgr0AlhdbVh4b+8w="
+      "integrity": "sha1-SaFUz4DphKywgr0AlhdbVh4b+8w=",
+      "dev": true
     },
     "apollo-tracing": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.0.7.tgz",
       "integrity": "sha512-jvjNmOOb3M2QiBEuz9Vjp6HiXtZuDwRvHxqBZQ+TE0UoODRnJoQu5LF1uvPI2ooOHiPC1ce4SAKNNIU9y02EeA==",
+      "dev": true,
       "requires": {
         "graphql-tools": "1.2.2"
       }
@@ -479,7 +486,8 @@
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true
     },
     "call": {
       "version": "4.0.2",
@@ -587,6 +595,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/co-body/-/co-body-5.1.1.tgz",
       "integrity": "sha1-2XeB0eM0S6SoIP0YBr3fg0FQUjY=",
+      "dev": true,
       "requires": {
         "inflation": "2.0.0",
         "qs": "6.5.0",
@@ -617,6 +626,56 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "connect": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.5.tgz",
+      "integrity": "sha1-+43ee6B2OHfQ7J352sC0tA5yx9o=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "finalhandler": "1.0.6",
+        "parseurl": "1.3.2",
+        "utils-merge": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "finalhandler": {
+          "version": "1.0.6",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
+          "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.2",
+            "statuses": "1.3.1",
+            "unpipe": "1.0.0"
+          }
+        },
+        "parseurl": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+          "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+          "dev": true
+        },
+        "utils-merge": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+          "dev": true
+        }
+      }
+    },
     "content": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/content/-/content-3.0.6.tgz",
@@ -646,12 +705,14 @@
     "content-disposition": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
     },
     "content-type": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
+      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
+      "dev": true
     },
     "cookie": {
       "version": "0.3.1",
@@ -669,6 +730,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.1.tgz",
       "integrity": "sha1-fIphX1SBxhq58WyDNzG8uPZjuZs=",
+      "dev": true,
       "requires": {
         "depd": "1.1.1",
         "keygrip": "1.0.2"
@@ -677,7 +739,8 @@
     "copy-to": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/copy-to/-/copy-to-2.0.1.tgz",
-      "integrity": "sha1-JoD7uAaKSNCGVrYJgJK9r8kG9KU="
+      "integrity": "sha1-JoD7uAaKSNCGVrYJgJK9r8kG9KU=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -711,6 +774,7 @@
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -727,7 +791,8 @@
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -737,22 +802,26 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+      "dev": true
     },
     "deprecated-decorator": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
-      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc="
+      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc=",
+      "dev": true
     },
     "destroy": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
     },
     "diff": {
       "version": "3.2.0",
@@ -772,7 +841,8 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
     },
     "encodeurl": {
       "version": "1.0.1",
@@ -783,12 +853,14 @@
     "error-inject": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/error-inject/-/error-inject-1.0.0.tgz",
-      "integrity": "sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc="
+      "integrity": "sha1-4rPZG1Su1nLzCdlQ0VSFD6EdTzc=",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -887,7 +959,8 @@
     "fresh": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
+      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
+      "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -949,6 +1022,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-1.2.2.tgz",
       "integrity": "sha512-FBcpceJMOYq8PEI8c40S5vAiCtwWh9vSrJc4DoanAiQOLC8DOXaZ8nY+3+/AwHRur+R+zDprGoL14QqcWr0RrA==",
+      "dev": true,
       "requires": {
         "@types/graphql": "0.9.4",
         "deprecated-decorator": "0.1.6",
@@ -1087,6 +1161,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.3.0.tgz",
       "integrity": "sha1-oxpc+IyHPsu1eWkH1NbxMujAHko=",
+      "dev": true,
       "requires": {
         "deep-equal": "1.0.1",
         "http-errors": "1.6.2"
@@ -1096,6 +1171,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
       "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+      "dev": true,
       "requires": {
         "depd": "1.1.1",
         "inherits": "2.0.3",
@@ -1116,12 +1192,14 @@
     "iconv-lite": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
     },
     "inflation": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/inflation/-/inflation-2.0.0.tgz",
-      "integrity": "sha1-i0F+R8KPklpFEz2RTKH9OJEH8w8="
+      "integrity": "sha1-i0F+R8KPklpFEz2RTKH9OJEH8w8=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -1136,7 +1214,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ipaddr.js": {
       "version": "1.4.0",
@@ -1184,7 +1263,8 @@
     "is-generator-function": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.6.tgz",
-      "integrity": "sha1-nnFlPNFf/zQcecQVFGChMdMen8Q="
+      "integrity": "sha1-nnFlPNFf/zQcecQVFGChMdMen8Q=",
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1194,7 +1274,8 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "isemail": {
       "version": "2.2.1",
@@ -1295,12 +1376,14 @@
     "keygrip": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.2.tgz",
-      "integrity": "sha1-rTKXxVcGneqLz+ek+kkbdcXd65E="
+      "integrity": "sha1-rTKXxVcGneqLz+ek+kkbdcXd65E=",
+      "dev": true
     },
     "koa": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/koa/-/koa-2.3.0.tgz",
       "integrity": "sha1-nh6OTaQBg5xXuFJ+rcV/dhJ1Vac=",
+      "dev": true,
       "requires": {
         "accepts": "1.3.3",
         "content-disposition": "0.5.2",
@@ -1332,6 +1415,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/koa-bodyparser/-/koa-bodyparser-4.2.0.tgz",
       "integrity": "sha1-vObgi8Zfhwm20fqpQRx/DYk4qlQ=",
+      "dev": true,
       "requires": {
         "co-body": "5.1.1",
         "copy-to": "2.0.1"
@@ -1340,12 +1424,14 @@
     "koa-compose": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-4.0.0.tgz",
-      "integrity": "sha1-KAClE9nDYe8NY4UrA45Pby1adzw="
+      "integrity": "sha1-KAClE9nDYe8NY4UrA45Pby1adzw=",
+      "dev": true
     },
     "koa-convert": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/koa-convert/-/koa-convert-1.2.0.tgz",
       "integrity": "sha1-2kCHXfSd4FOQmNFwC1CCDOvNIdA=",
+      "dev": true,
       "requires": {
         "co": "4.6.0",
         "koa-compose": "3.2.1"
@@ -1355,6 +1441,7 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
           "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
+          "dev": true,
           "requires": {
             "any-promise": "1.3.0"
           }
@@ -1364,12 +1451,14 @@
     "koa-is-json": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz",
-      "integrity": "sha1-JzwH7c3Ljfaiwat9We52SRRR7BQ="
+      "integrity": "sha1-JzwH7c3Ljfaiwat9We52SRRR7BQ=",
+      "dev": true
     },
     "koa-router": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/koa-router/-/koa-router-7.2.1.tgz",
       "integrity": "sha1-tApKs8attLQIld69AKnGQDBOMDk=",
+      "dev": true,
       "requires": {
         "debug": "2.6.8",
         "http-errors": "1.6.2",
@@ -1382,6 +1471,7 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/koa-compose/-/koa-compose-3.2.1.tgz",
           "integrity": "sha1-qFzLQLfZhtjlo0Wzoazo6rz1Tec=",
+          "dev": true,
           "requires": {
             "any-promise": "1.3.0"
           }
@@ -1390,6 +1480,7 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
           "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
           "requires": {
             "isarray": "0.0.1"
           }
@@ -1473,7 +1564,8 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -1484,7 +1576,8 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
     },
     "mime": {
       "version": "1.3.4",
@@ -1570,12 +1663,14 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
     },
     "nigel": {
       "version": "2.0.2",
@@ -1604,6 +1699,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
       "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
       "requires": {
         "ee-first": "1.1.1"
       }
@@ -1620,12 +1716,14 @@
     "only": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/only/-/only-0.0.2.tgz",
-      "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q="
+      "integrity": "sha1-Kv3oTQPlC5qO3EROMGEKcCle37Q=",
+      "dev": true
     },
     "parseurl": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1729,6 +1827,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
       "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "http-errors": "1.6.2",
@@ -1837,7 +1936,8 @@
     "setprototypeof": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+      "dev": true
     },
     "shot": {
       "version": "3.4.2",
@@ -1930,7 +2030,8 @@
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "dev": true
     },
     "stealthy-require": {
       "version": "1.1.1",
@@ -2039,6 +2140,7 @@
       "version": "1.6.15",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "dev": true,
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "2.1.16"
@@ -2053,7 +2155,8 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.0",
@@ -2069,7 +2172,8 @@
     "vary": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
-      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
+      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
+      "dev": true
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -36,12 +36,17 @@
     "@types/request": "^2.0.0",
     "apollo-server-express": "^1.1.2",
     "apollo-server-hapi": "^1.1.2",
+    "apollo-server-koa": "^1.1.2",
     "body-parser": "^1.18.1",
     "chai": "^4.1.2",
     "express": "^4.15.4",
     "graphql": "^0.11.3",
     "hapi": "^16.6.0",
+    "koa": "^2.3.0",
+    "koa-bodyparser": "^4.2.0",
+    "koa-router": "^7.2.1",
     "mocha": "^3.5.3",
+    "request-promise-native": "^1.0.5",
     "typescript": "^2.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "apollo-server-koa": "^1.1.2",
     "body-parser": "^1.18.1",
     "chai": "^4.1.2",
+    "connect": "^3.6.5",
     "express": "^4.15.4",
     "graphql": "^0.11.3",
     "hapi": "^16.6.0",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,6 +14,7 @@ export class MiddlewareParams {
 export function makeExpressMiddleware(params: MiddlewareParams) {
     return function (req: Request, res: Response, next: NextFunction) {
         if (!params.uri || req.path != params.endpoint) next();
+        else if (req.method != 'GET' && req.method != 'POST') next();
         else if (req.headers['x-engine-from'] === params.psk) next();
         else proxyRequest(params, req, res);
     }
@@ -22,6 +23,7 @@ export function makeExpressMiddleware(params: MiddlewareParams) {
 export function makeConnectMiddleware(params: MiddlewareParams) {
     return function (req: any, res: any, next: any) {
         if (!params.uri || req.originalUrl != params.endpoint) next();
+        else if (req.method != 'GET' && req.method != 'POST') next();
         else if (req.headers['x-engine-from'] === params.psk) next();
         else proxyRequest(params, req, res);
     }
@@ -31,6 +33,7 @@ export function makeKoaMiddleware(params: MiddlewareParams) {
     return function (ctx: Context, next: () => Promise<any>) {
         if (!params.uri || ctx.originalUrl != params.endpoint) return next();
         else if (ctx.req.headers['x-engine-from'] === params.psk) return next();
+        else if (ctx.req.method != 'GET' && ctx.req.method != 'POST') return next();
         else return new Promise((resolve) => {
                 ctx.req.pipe(request(params.uri + params.endpoint, (error, response, body) => {
                     if (response.statusCode) ctx.response.status = response.statusCode;
@@ -48,6 +51,7 @@ export function instrumentHapi(server: Server, params: MiddlewareParams) {
         if (!params.uri) return reply.continue();
         const path = req.url.path;
         if (!path || path != params.endpoint) return reply.continue();
+        else if (req.method !== 'get' && req.method !== 'post') return reply.continue();
         else if (req.headers['x-engine-from'] === params.psk) return reply.continue();
         else proxyRequest(params, req.raw.req, req.raw.res);
     });

--- a/test/connect.js
+++ b/test/connect.js
@@ -1,0 +1,70 @@
+const connect = require('connect');
+const bodyParser = require('body-parser');
+const {graphqlConnect} = require('apollo-server-express');
+const http = require('http');
+
+const {Engine} = require('../lib/index');
+const {schema, rootValue, verifyEndpointSuccess, verifyEndpointFailure, verifyEndpointError} = require('./schema');
+const {startWithDelay} = require('./test');
+
+describe('connect middleware', () => {
+  let app;
+  beforeEach(() => {
+    app = new connect();
+  });
+
+  function gqlServer() {
+    app.use('/graphql', bodyParser.json());
+    app.use('/graphql', graphqlConnect({
+      schema,
+      rootValue,
+      tracing: true
+    }));
+    return http.createServer(app).listen(0);
+  }
+
+  describe('without engine', () => {
+    let url;
+    beforeEach(() => {
+      let server = gqlServer();
+      url = `http://localhost:${server.address().port}/graphql`;
+    });
+
+    it('processes successful query', () => {
+      return verifyEndpointSuccess(url, true);
+    });
+    it('processes invalid query', () => {
+      return verifyEndpointFailure(url);
+    });
+    it('processes query that errors', () => {
+      return verifyEndpointError(url);
+    });
+  });
+
+  describe('with engine', () => {
+    let url;
+    beforeEach(async () => {
+      let engine = new Engine({
+        engineConfig: {
+          apiKey: 'faked'
+        },
+        graphqlPort: 1,
+      });
+      app.use(engine.connectMiddleware());
+      let server = gqlServer();
+      engine.graphqlPort = server.address().port;
+      await startWithDelay(engine);
+      url = `http://localhost:${engine.graphqlPort}/graphql`;
+    });
+
+    it('processes successful query', () => {
+      return verifyEndpointSuccess(url, false);
+    });
+    it('processes invalid query', () => {
+      return verifyEndpointFailure(url);
+    });
+    it('processes query that errors', () => {
+      return verifyEndpointError(url);
+    });
+  });
+});

--- a/test/connect.js
+++ b/test/connect.js
@@ -5,7 +5,7 @@ const http = require('http');
 
 const {Engine} = require('../lib/index');
 const {schema, rootValue, verifyEndpointSuccess, verifyEndpointFailure, verifyEndpointError} = require('./schema');
-const {startWithDelay} = require('./test');
+const {startWithDelay, testEngine} = require('./test');
 
 describe('connect middleware', () => {
   let app;
@@ -44,12 +44,7 @@ describe('connect middleware', () => {
   describe('with engine', () => {
     let url;
     beforeEach(async () => {
-      let engine = new Engine({
-        engineConfig: {
-          apiKey: 'faked'
-        },
-        graphqlPort: 1,
-      });
+      let engine = testEngine();
       app.use(engine.connectMiddleware());
       let server = gqlServer();
       engine.graphqlPort = server.address().port;

--- a/test/express.js
+++ b/test/express.js
@@ -9,7 +9,7 @@ const {assert} = require('chai');
 
 const {Engine} = require('../lib/index');
 const {schema, rootValue, verifyEndpointSuccess, verifyEndpointFailure, verifyEndpointError} = require('./schema');
-const {startWithDelay} = require('./test');
+const {startWithDelay, testEngine} = require('./test');
 
 describe('express middleware', () => {
   // Start graphql-express on a random port:
@@ -34,16 +34,7 @@ describe('express middleware', () => {
   }
 
   function setupEngine(path) {
-    path = path || '/graphql';
-
-    // Install middleware before GraphQL handler:
-    let engine = new Engine({
-      endpoint: path,
-      engineConfig: {
-        apiKey: 'faked'
-      },
-      graphqlPort: 1
-    });
+    let engine = testEngine(path);
     app.use(engine.expressMiddleware());
 
     engine.graphqlPort = gqlServer(path);

--- a/test/hapi.js
+++ b/test/hapi.js
@@ -15,6 +15,13 @@ describe('hapi middleware', () => {
       port: 0
     });
 
+    server.route({
+      method: 'OPTIONS',
+      path: '/graphql',
+      handler: (req, reply) => {
+        return reply('ok');
+      }
+    });
     server.register({
       register: graphqlHapi,
       options: {
@@ -65,7 +72,7 @@ describe('hapi middleware', () => {
         // Then start engine:
         let engine = new Engine({
           engineConfig: {
-            apiKey: "faked",
+            apiKey: "faked"
           },
           graphqlPort: port
         });
@@ -87,16 +94,13 @@ describe('hapi middleware', () => {
       verifyEndpointError(url, done);
     });
 
-    // TODO: validating behaviour when a specific bug is triggered
-    // This test is useless in the long term
-    it('processes empty request', (done) => {
-      request.post({
-        url,
-        body: ''
-      }, function (err, response, body) {
-        body = JSON.parse(response.body);
-        assert.strictEqual('The query failed!', body['errors'][0]['message']);
-        verifyEndpointSuccess(url, false, done);
+    it('ignores options request', (done) => {
+      request({
+        method: 'OPTIONS',
+        url
+      }, (err, response, body) => {
+        assert.strictEqual(200, response.statusCode)
+        done();
       });
     });
   });

--- a/test/hapi.js
+++ b/test/hapi.js
@@ -2,9 +2,10 @@ const hapi = require('hapi');
 const {graphqlHapi} = require('apollo-server-hapi');
 
 const {assert} = require('chai');
-const request = require('request');
+const request = require('request-promise-native');
 const {Engine} = require('../lib/index');
 const {schema, rootValue, verifyEndpointSuccess, verifyEndpointFailure, verifyEndpointError} = require('./schema');
+const {startWithDelay} = require('./test');
 
 describe('hapi middleware', () => {
   let server;
@@ -37,71 +38,57 @@ describe('hapi middleware', () => {
 
   describe('without engine', () => {
     let url;
-    beforeEach((done) => {
-      server.start((err) => {
-        if (err) {
-          throw err;
-        }
-        url = `http://localhost:${server.info.port}/graphql`;
-        done();
-      });
+    beforeEach(async () => {
+      await server.start();
+      url = `http://localhost:${server.info.port}/graphql`;
     });
 
-    it('processes successful query', (done) => {
-      verifyEndpointSuccess(url, true, done);
+    it('processes successful query', () => {
+      return verifyEndpointSuccess(url, true);
     });
-    it('processes invalid query', (done) => {
-      verifyEndpointFailure(url, done);
+    it('processes invalid query', () => {
+      return verifyEndpointFailure(url);
     });
-    it('processes query that errors', (done) => {
-      verifyEndpointError(url, done);
+    it('processes query that errors', () => {
+      return verifyEndpointError(url);
     });
   });
 
   describe('with engine', () => {
     let url;
-    beforeEach((done) => {
-      // Start server:
-      server.start((err) => {
-        if (err) {
-          throw err;
-        }
-        let port = server.info.port;
-        url = `http://localhost:${port}/graphql`;
+    beforeEach(async () => {
+      await server.start();
 
-        // Then start engine:
-        let engine = new Engine({
-          engineConfig: {
-            apiKey: "faked"
-          },
-          graphqlPort: port
-        });
-        engine.instrumentHapiServer(server);
-        engine.start();
+      let port = server.info.port;
+      url = `http://localhost:${port}/graphql`;
 
-        // Hack to wait for proxy process to launch and bind:
-        setTimeout(done, 100);
+      // Then start engine:
+      let engine = new Engine({
+        engineConfig: {
+          apiKey: 'faked'
+        },
+        graphqlPort: port
       });
+      engine.instrumentHapiServer(server);
+      await startWithDelay(engine);
     });
 
-    it('processes successful query', (done) => {
-      verifyEndpointSuccess(url, false, done);
+    it('processes successful query', () => {
+      return verifyEndpointSuccess(url, false);
     });
-    it('processes invalid query', (done) => {
-      verifyEndpointFailure(url, done);
+    it('processes invalid query', () => {
+      return verifyEndpointFailure(url);
     });
-    it('processes query that errors', (done) => {
-      verifyEndpointError(url, done);
+    it('processes query that errors', () => {
+      return verifyEndpointError(url);
     });
 
-    it('ignores options request', (done) => {
-      request({
+    it('ignores options request', async () => {
+      let response = await request({
         method: 'OPTIONS',
         url
-      }, (err, response, body) => {
-        assert.strictEqual(200, response.statusCode)
-        done();
       });
+      assert.strictEqual('ok', response);
     });
   });
 });

--- a/test/hapi.js
+++ b/test/hapi.js
@@ -5,7 +5,7 @@ const {assert} = require('chai');
 const request = require('request-promise-native');
 const {Engine} = require('../lib/index');
 const {schema, rootValue, verifyEndpointSuccess, verifyEndpointFailure, verifyEndpointError} = require('./schema');
-const {startWithDelay} = require('./test');
+const {startWithDelay, testEngine} = require('./test');
 
 describe('hapi middleware', () => {
   let server;
@@ -63,12 +63,8 @@ describe('hapi middleware', () => {
       url = `http://localhost:${port}/graphql`;
 
       // Then start engine:
-      let engine = new Engine({
-        engineConfig: {
-          apiKey: 'faked'
-        },
-        graphqlPort: port
-      });
+      let engine = testEngine();
+      engine.graphqlPort = port;
       engine.instrumentHapiServer(server);
       await startWithDelay(engine);
     });

--- a/test/koa.js
+++ b/test/koa.js
@@ -5,7 +5,7 @@ const {graphqlKoa} = require('apollo-server-koa');
 
 const {Engine} = require('../lib/index');
 const {schema, rootValue, verifyEndpointSuccess, verifyEndpointFailure, verifyEndpointError} = require('./schema');
-const {startWithDelay} = require('./test');
+const {startWithDelay, testEngine} = require('./test');
 
 describe('koa middleware', () => {
   let app;
@@ -49,12 +49,7 @@ describe('koa middleware', () => {
   describe('with engine', () => {
     let url;
     beforeEach(async () => {
-      let engine = new Engine({
-        engineConfig: {
-          apiKey: 'faked'
-        },
-        graphqlPort: 1,
-      });
+      let engine = testEngine();
       app.use(engine.koaMiddleware());
       let server = gqlServer();
       engine.graphqlPort = server.address().port;

--- a/test/koa.js
+++ b/test/koa.js
@@ -1,0 +1,76 @@
+const koa = require('koa');
+const koaRouter = require('koa-router');
+const koaBody = require('koa-bodyparser');
+const {graphqlKoa} = require('apollo-server-koa');
+
+const {Engine} = require('../lib/index');
+const {schema, rootValue, verifyEndpointSuccess, verifyEndpointFailure, verifyEndpointError} = require('./schema');
+const {startWithDelay} = require('./test');
+
+describe('koa middleware', () => {
+  let app;
+
+  function gqlServer() {
+    let graphqlHandler = graphqlKoa({
+      schema,
+      rootValue,
+      tracing: true
+    });
+    const router = new koaRouter();
+    router.post('/graphql', koaBody(), graphqlHandler);
+    router.get('/graphql', graphqlHandler);
+    app.use(router.routes());
+    app.use(router.allowedMethods());
+    return app.listen(0);
+  }
+
+  beforeEach(() => {
+    app = new koa();
+  });
+
+  describe('without engine', () => {
+    let url;
+    beforeEach(() => {
+      let server = gqlServer();
+      url = `http://localhost:${server.address().port}/graphql`;
+    });
+
+    it('processes successful query', () => {
+      return verifyEndpointSuccess(url, true);
+    });
+    it('processes invalid query', () => {
+      return verifyEndpointFailure(url);
+    });
+    it('processes query that errors', () => {
+      return verifyEndpointError(url);
+    });
+  });
+
+  describe('with engine', () => {
+    let url;
+    beforeEach(async () => {
+      let engine = new Engine({
+        engineConfig: {
+          apiKey: 'faked'
+        },
+        graphqlPort: 1,
+      });
+      app.use(engine.koaMiddleware());
+      let server = gqlServer();
+      engine.graphqlPort = server.address().port;
+      await startWithDelay(engine);
+
+      url = `http://localhost:${engine.graphqlPort}/graphql`;
+    });
+
+    it('processes successful query', () => {
+      return verifyEndpointSuccess(url, false);
+    });
+    it('processes invalid query', () => {
+      return verifyEndpointFailure(url);
+    });
+    it('processes query that errors', () => {
+      return verifyEndpointError(url);
+    });
+  });
+});

--- a/test/schema.js
+++ b/test/schema.js
@@ -19,48 +19,54 @@ exports.rootValue = {
 };
 
 
-exports.verifyEndpointSuccess = function (url, tracing, done) {
-  request.post({
-    url,
-    json: true,
-    body: {'query': '{ hello }'}
-  }, function (err, response, body) {
-    assert.strictEqual('Hello World', body['data']['hello']);
-    if (tracing) {
-      assert.notEqual(undefined, body['extensions'] && body['extensions']['tracing']);
-    } else {
-      assert.strictEqual(undefined, body['extensions'] && body['extensions']['tracing']);
-    }
-    done();
+exports.verifyEndpointSuccess = (url, hasTracing) => {
+  return new Promise((resolve) => {
+    request.post({
+      url,
+      json: true,
+      body: {'query': '{ hello }'}
+    }, (err, response, body) => {
+      assert.strictEqual('Hello World', body['data']['hello']);
+      if (hasTracing) {
+        assert.notEqual(undefined, body['extensions'] && body['extensions']['tracing']);
+      } else {
+        assert.strictEqual(undefined, body['extensions'] && body['extensions']['tracing']);
+      }
+      resolve();
+    });
+  })
+};
+
+exports.verifyEndpointFailure = (url) => {
+  return new Promise((resolve) => {
+    request.post({
+      url,
+      json: true,
+      body: {'query': '{ validButDoesNotComplyToSchema }'}
+    }, (err, response, body) => {
+      if (response.statusCode === 200) {
+        // Proxy responds with an error-ed 200:
+        assert.strictEqual('Cannot query field "validButDoesNotComplyToSchema" on type "Query".',
+          response.body['errors'][0]['message'])
+      } else {
+        // Express responds with a 400
+        assert.strictEqual(400, response.statusCode);
+      }
+      resolve();
+    });
   });
 };
 
-exports.verifyEndpointFailure = function (url, done) {
-  request.post({
-    url,
-    json: true,
-    body: {'query': '{ validButDoesNotComplyToSchema }'}
-  }, function (err, response, body) {
-    if (response.statusCode === 200) {
-      // Proxy responds with an error-ed 200:
-      assert.strictEqual('Cannot query field "validButDoesNotComplyToSchema" on type "Query".',
-        response.body['errors'][0]['message'])
-    } else {
-      // Express responds with a 400
-      assert.strictEqual(400, response.statusCode);
-    }
-    done();
-  });
-};
-
-exports.verifyEndpointError = function (url, done) {
-  request.post({
-    url,
-    json: true,
-    body: {'query': '{ errorTrigger }'}
-  }, function (err, response, body) {
-    assert.strictEqual(200, response.statusCode);
-    assert.strictEqual('Kaboom', body['errors'][0]['message']);
-    done();
+exports.verifyEndpointError = (url) => {
+  return new Promise((resolve) => {
+    request.post({
+      url,
+      json: true,
+      body: {'query': '{ errorTrigger }'}
+    }, (err, response, body) => {
+      assert.strictEqual(200, response.statusCode);
+      assert.strictEqual('Kaboom', body['errors'][0]['message']);
+      resolve();
+    });
   });
 };

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,23 @@
+const {Engine} = require('../lib/index');
+
 exports.startWithDelay = (engine) => {
   return new Promise((resolve) => {
     engine.start()
       .then(() => {
         setTimeout(resolve, 100);
       })
+  });
+};
+
+exports.testEngine = (path) => {
+  path = path || '/graphql';
+
+  // Install middleware before GraphQL handler:
+  return new Engine({
+    endpoint: path,
+    engineConfig: {
+      apiKey: 'faked'
+    },
+    graphqlPort: 1
   });
 };

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,8 @@
+exports.startWithDelay = (engine) => {
+  return new Promise((resolve) => {
+    engine.start()
+      .then(() => {
+        setTimeout(resolve, 100);
+      })
+  });
+};


### PR DESCRIPTION
The proxy doesn't handle these nicely, so let the local node app deal
with them.

* HAPI gets an automated test
* Express got a manual verification
* Connect and Koa don't have tests yet, but this seemed consistent with
docs (no testing!)