### PR TITLE
fix(EngineConfig): queryCache should be optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export interface EngineConfig {
         noTraceVariables?: boolean,
         privateHeaders?: string[],
     },
-    queryCache: {
+    queryCache?: {
         publicFullQueryStore?: string,
         privateFullQueryStore?: string,
     }


### PR DESCRIPTION
As per documentation, `queryCache ` ought to be an optional property.