### PR TITLE
supportsBatch shortcut

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
-import { ChildProcess, spawn } from 'child_process';
-import { randomBytes } from 'crypto';
-import { createServer } from 'net';
-import { resolve } from 'path';
-import { readFileSync, existsSync } from 'fs';
+import {ChildProcess, spawn} from 'child_process';
+import {randomBytes} from 'crypto';
+import {createServer} from 'net';
+import {resolve} from 'path';
+import {readFileSync, existsSync} from 'fs';
 
 import {
     MiddlewareParams,
@@ -30,8 +30,8 @@ export interface EngineConfig {
             url: string,
             headerSecret: string,
         }
-        supportsBatch?: boolean ,
-        requestTimeout?: string ,
+        supportsBatch?: boolean,
+        requestTimeout?: string,
         maxConcurrentRequests?: number,
     }[],
     frontends?: {
@@ -182,7 +182,9 @@ export class Engine {
                         if (typeof origin.http === 'object') {
                             origin.http.headerSecret = this.middlewareParams.psk;
                         }
-                        // Don't update `supportsBatch`
+                        if (origin.supportsBatch === undefined) {
+                            origin.supportsBatch = this.supportsBatch;
+                        }
                     });
                 }
 
@@ -250,6 +252,6 @@ export class Engine {
     }
 
     private engineLineWrapper(): any {
-        return new LineWrapper({ prefix: 'EngineProxy ==> ' });
+        return new LineWrapper({prefix: 'EngineProxy ==> '});
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export interface EngineConfig {
             url: string,
             headerSecret: string,
         }
+        supportsBatch?: boolean ,
         requestTimeout?: string ,
         maxConcurrentRequests?: number,
     }[],
@@ -79,7 +80,8 @@ export interface SideloadConfig {
     engineConfig: string | EngineConfig,
     endpoint?: string,
     graphqlPort?: number,
-    dumpTraffic?: boolean
+    dumpTraffic?: boolean,
+    supportsBatch?: boolean,
 }
 
 export class Engine {
@@ -88,6 +90,7 @@ export class Engine {
     private binary: string;
     private config: string | EngineConfig;
     private middlewareParams: MiddlewareParams;
+    private supportsBatch: boolean;
     private started: Boolean;
     private killed: Boolean;
 
@@ -98,6 +101,7 @@ export class Engine {
         this.middlewareParams.endpoint = config.endpoint || '/graphql';
         this.middlewareParams.psk = randomBytes(48).toString("hex");
         this.middlewareParams.dumpTraffic = config.dumpTraffic || false;
+        this.supportsBatch = config.supportsBatch || false;
         if (config.graphqlPort) {
             this.graphqlPort = config.graphqlPort;
         } else {
@@ -169,7 +173,8 @@ export class Engine {
                         http: {
                             url: 'http://127.0.0.1:' + graphqlPort + endpoint,
                             headerSecret: this.middlewareParams.psk
-                        }
+                        },
+                        supportsBatch: this.supportsBatch,
                     }];
                 } else {
                     // Extend any existing HTTP origins with the chosen PSK:
@@ -177,7 +182,8 @@ export class Engine {
                         if (typeof origin.http === 'object') {
                             origin.http.headerSecret = this.middlewareParams.psk;
                         }
-                    })
+                        // Don't update `supportsBatch`
+                    });
                 }
 
                 let binaryPath = resolve(__dirname, '../node_modules', this.binary);

--- a/test/schema.js
+++ b/test/schema.js
@@ -37,6 +37,29 @@ exports.verifyEndpointSuccess = (url, hasTracing) => {
   })
 };
 
+exports.verifyEndpointBatch = (url, hasTracing) => {
+  return new Promise((resolve) => {
+    request.post({
+      url,
+      json: true,
+      body: [{'query': '{ hello }'}, {'query': '{ hello }'}]
+    }, (err, response, body) => {
+      assert.strictEqual(2, body.length);
+
+      body.forEach(body => {
+        assert.strictEqual('Hello World', body['data']['hello']);
+        if (hasTracing) {
+          assert.notEqual(undefined, body['extensions'] && body['extensions']['tracing']);
+        } else {
+          assert.strictEqual(undefined, body['extensions'] && body['extensions']['tracing']);
+        }
+      });
+
+      resolve();
+    });
+  })
+};
+
 exports.verifyEndpointFailure = (url) => {
   return new Promise((resolve) => {
     request.post({


### PR DESCRIPTION
Previously this flag required defining an origin (and ignoring
TypeScript types!) - accept `supportsBatch: boolean` option to avoid
making users dive into origin config.

Fixes #43 