### PR TITLE
Improvements under load

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -83,7 +83,16 @@ function proxyRequest(params: MiddlewareParams, req: IncomingMessage, res: Serve
         req.pipe(process.stdout);
     }
 
-    let proxyRes = req.pipe(request(params.uri + req.url));
+    const proxyRes = req.pipe(request({
+        uri: params.uri + req.url,
+        forever: true,
+    }))
+        .on('error', (err) => {
+            console.error(err);
+            res.writeHead(503);
+            res.end();
+        });
+
     if (params.dumpTraffic) {
         proxyRes.pipe(process.stdout);
     }


### PR DESCRIPTION
- enable Keep-Alive when communicating with proxy to avoid socket
starvation
- log and return error on proxy failure, i.e. if sockets are starved
because of --^. Previously the node process would crash.