### PR TITLE
Improve error message for no GraphQL Port

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -137,14 +137,14 @@ export class Engine extends EventEmitter {
             this.graphqlPort = config.graphqlPort;
         } else {
             const port : any = process.env.PORT;
-            if (!isNaN(port) && isFinite(port)) {
+            if (isFinite(port)) {
                 this.graphqlPort = parseInt(port, 10);
             } else {
                 throw new Error(`Neither 'graphqlPort' nor process.env.PORT is set. ` +
-                    `In order for Apollo Engine to act as a proxy for your GraphQL server,` +
-                    `it needs to know which port your GraphQL server is (this is the port number` +
-                    `that comes before '/graphql'). If you see this error, you should make sure to` +
-                    `add e.g. 'graphqlPort: 1234' wherever you call new Engine(...).`);
+                    `In order for Apollo Engine to act as a proxy for your GraphQL server, ` +
+                    `it needs to know which port your GraphQL server is listening on (this is ` +
+                    `the port number that comes before '/graphql'). If you see this error, you ` +
+                    `should make sure to add e.g. 'graphqlPort: 1234' wherever you call new Engine(...).`);
             }
         }
         this.config = config.engineConfig;

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,11 +136,15 @@ export class Engine extends EventEmitter {
         if (config.graphqlPort) {
             this.graphqlPort = config.graphqlPort;
         } else {
-            const port = process.env.PORT;
-            if (port) {
+            const port : any = process.env.PORT;
+            if (!isNaN(port) && isFinite(port)) {
                 this.graphqlPort = parseInt(port, 10);
             } else {
-                throw new Error('process.env.PORT is not set!');
+                throw new Error(`Neither 'graphqlPort' nor process.env.PORT is set. ` +
+                    `In order for Apollo Engine to act as a proxy for your GraphQL server,` +
+                    `it needs to know which port your GraphQL server is (this is the port number` +
+                    `that comes before '/graphql'). If you see this error, you should make sure to` +
+                    `add e.g. 'graphqlPort: 1234' wherever you call new Engine(...).`);
             }
         }
         this.config = config.engineConfig;


### PR DESCRIPTION
This also allows ports with value '0' and disallows non-numeric ports