### PR TITLE
Allows full configuration from Engine config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This is the minimum necessary information in the engine configuration object to 
   "dumpTraffic": false,             // If true, HTTP requests and responses will be dumped to stdout. Should only be used if debugging an issue.
   "startupTimeout": 5000,           // If >0, .start() will throw if the proxy binary does not finish startup within the given number of milliseconds.
                                     // Defaults to 5000ms if not set.
+  "allowFullConfiguration": true    // For use with single proxy mode. Set this to true this if configuring frontends and origins directly in the engineConfig.
 
   // Shortcuts to "origins" in EngineConfig
   "origin": {

--- a/test/engine.js
+++ b/test/engine.js
@@ -148,28 +148,28 @@ describe('engine', () => {
       engine = new Engine({
         allowFullConfiguration: true,
         engineConfig: {
-          apiKey: "faked",
+          apiKey: 'faked',
           origins: [
             {
-              name: "defaultOrigin",
+              name: 'defaultOrigin',
               http: {
-                url: 'http://127.0.0.1:' + defaultPort + "/graphql"
+                url: `http://127.0.0.1:${defaultPort}/graphql`
               }
             },
             {
-              name: "testOrigin",
+              name: 'testOrigin',
               http: {
-                url: 'http://127.0.0.1:' + testPort + "/test/graphql"
+                url: `http://127.0.0.1:${testPort}/graphql`
               }
             }
           ],
           frontends: [
             {
-              host: "127.0.0.1",
+              host: '127.0.0.1',
               port: 3000,
               endpointMap: {
-                "/graphql" : "defaultOrigin",
-                "/test/graphql" : "testOrigin"
+                '/graphql' : 'defaultOrigin',
+                '/test/graphql' : 'testOrigin',
               }
             }
           ],
@@ -221,8 +221,8 @@ describe('engine', () => {
 
     it('accepts configuration of overridden headers', async () => {
       const overrideRequestHeaders = {
-        "Host": "example.com",
-        "X-Does-Not-Exist": "huehue",
+        'Host': 'example.com',
+        'X-Does-Not-Exist': 'huehue',
       };
       engine = new Engine({
         graphqlPort: 1,

--- a/test/engine.js
+++ b/test/engine.js
@@ -129,19 +129,61 @@ describe('engine', () => {
       let port = gqlServer('/graphql');
 
       engine = new Engine({
-        endpoint: '/graphql',
         engineConfig: 'test/engine.json',
         graphqlPort: port,
         frontend: {
           host: '127.0.0.1',
           port: 3000,
-          endpoint: '/graphql'
         }
       });
 
       await engine.start();
-      return verifyEndpointSuccess('http://localhost:3000/graphql', false);
+      await verifyEndpointSuccess('http://localhost:3000/graphql', false);
     });
+
+
+    it('can be configured in single proxy mode to use multiple endpoints', async () => {
+      let testPort = gqlServer('/test/graphql');
+      let defaultPort = gqlServer('/graphql');
+      engine = new Engine({
+        allowFullConfiguration: true,
+        engineConfig: {
+          apiKey: "faked",
+          origins: [
+            {
+              name: "defaultOrigin",
+              http: {
+                url: 'http://127.0.0.1:' + defaultPort + "/graphql"
+              }
+            },
+            {
+              name: "testOrigin",
+              http: {
+                url: 'http://127.0.0.1:' + testPort + "/test/graphql"
+              }
+            }
+          ],
+          frontends: [
+            {
+              host: "127.0.0.1",
+              port: 3000,
+              endpointMap: {
+                "/graphql" : "defaultOrigin",
+                "/test/graphql" : "testOrigin"
+              }
+            }
+          ],
+          reporting: {
+            disabled: true,
+            noTraceVariables: true
+          }
+        }
+      });
+
+      await engine.start()
+      await verifyEndpointSuccess('http://localhost:3000/graphql', false);
+      await verifyEndpointSuccess('http://localhost:3000/test/graphql', false);
+    })
 
     it('sets default startup timeout', () => {
       engine = new Engine({


### PR DESCRIPTION
* This should realistically only be used in single-proxy mode. Rather than not overriding anything, this change will make it so that things that are already set via the config are left alone (namely frontends and origins).
* Also includes a test which demonstrates how this could be used to enable features like 'endpointMap'
* Also changes standard path to use the recommended 'endpoints' field rather than the deprecated 'endpoint' field.

TODO
- [x] Remark on the added field in README.md