### PR TITLE
Adam/allow no overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ This is the minimum necessary information in the engine configuration object to 
   "dumpTraffic": false,             // If true, HTTP requests and responses will be dumped to stdout. Should only be used if debugging an issue.
   "startupTimeout": 5000,           // If >0, .start() will throw if the proxy binary does not finish startup within the given number of milliseconds.
                                     // Defaults to 5000ms if not set.
+<<<<<<< HEAD
   "allowFullConfiguration": true    // For use with single proxy mode. Set this to true if configuring frontends and origins directly in the engineConfig.
+=======
+  "allowFullConfiguration": true    // For use with single proxy mode. Set this to true this if configuring frontends and origins directly in the engineConfig.
+>>>>>>> Add configuration information to README
 
   // Shortcuts to "origins" in EngineConfig
   "origin": {

--- a/README.md
+++ b/README.md
@@ -61,11 +61,7 @@ This is the minimum necessary information in the engine configuration object to 
   "dumpTraffic": false,             // If true, HTTP requests and responses will be dumped to stdout. Should only be used if debugging an issue.
   "startupTimeout": 5000,           // If >0, .start() will throw if the proxy binary does not finish startup within the given number of milliseconds.
                                     // Defaults to 5000ms if not set.
-<<<<<<< HEAD
-  "allowFullConfiguration": true    // For use with single proxy mode. Set this to true if configuring frontends and origins directly in the engineConfig.
-=======
-  "allowFullConfiguration": true    // For use with single proxy mode. Set this to true this if configuring frontends and origins directly in the engineConfig.
->>>>>>> Add configuration information to README
+  "useConfigPrecisely": true        // For use with single proxy mode. Set this to true for the spawned Engine proxy process to use the engineConfig object specified in the constructor. All other fields will be ignored.
 
   // Shortcuts to "origins" in EngineConfig
   "origin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -318,7 +318,6 @@ export class Engine extends EventEmitter {
                 if (listeningAddress !== '') {
                     this.middlewareParams.uri = `http://${listeningAddress}`;
                     // Notify that proxy has started.
-                    console.log('STARTING ENGINE PROXY');
                     this.emit('start');
                 }
             });

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,19 +26,20 @@ export interface ExtensionsConfig {
     blacklist?: string[],
 }
 
-// User-configurable fields of EngineConfig "frontend"
+// Shortcut to user-configurable fields of EngineConfig "frontend" in default double-proxy mode
 export interface FrontendParams {
     extensions?: ExtensionsConfig,
 }
 
-// All configuration of "frontend" (including fields managed by apollo-engine-js)
+// All configuration of default "frontend" (including fields managed by apollo-engine-js)
 export interface FrontendConfig extends FrontendParams {
     host: string,
-    endpoints: string[],
+    endpoint?: string,
+    endpoints?: string[],
     port: number,
 }
 
-// User-configurable fields of EngineConfig "origin"
+// Shortcut to user-configurable fields of EngineConfig "origin" in default double-proxy mode
 export interface OriginParams {
     requestTimeout?: string,
     maxConcurrentRequests?: number,
@@ -117,7 +118,7 @@ export interface EngineConfig {
 export interface SideloadConfig {
     engineConfig: string | EngineConfig,
     endpoint?: string,
-    allowFullConfiguration?: boolean,
+    useConfigPrecisely?: boolean,
     graphqlPort?: number,
     // Should all requests/responses to the proxy be written to stdout?
     dumpTraffic?: boolean,
@@ -135,7 +136,7 @@ export class Engine extends EventEmitter {
     private proxyStdoutStream?: NodeJS.WritableStream;
     private proxyStderrStream?: NodeJS.WritableStream;
     private graphqlPort?: number;
-    private allowFullConfiguration: boolean;
+    private useConfigPrecisely: boolean;
     private binary: string;
     private config: string | EngineConfig;
     private middlewareParams: MiddlewareParams;
@@ -156,7 +157,7 @@ export class Engine extends EventEmitter {
         this.middlewareParams.endpoint = config.endpoint || '/graphql';
         this.middlewareParams.psk = randomBytes(48).toString("hex");
         this.middlewareParams.dumpTraffic = config.dumpTraffic || false;
-        this.allowFullConfiguration = config.allowFullConfiguration || false;
+        this.useConfigPrecisely = config.useConfigPrecisely || false;
         this.originParams = config.origin || {};
         this.frontendParams = config.frontend || {};
         if (config.proxyStdoutStream) {
@@ -165,14 +166,13 @@ export class Engine extends EventEmitter {
         if (config.proxyStderrStream) {
             this.proxyStderrStream = config.proxyStderrStream;
         }
-
         if (config.graphqlPort) {
             this.graphqlPort = config.graphqlPort;
         } else {
             const port: any = process.env.PORT;
             if (isFinite(port)) {
                 this.graphqlPort = parseInt(port, 10);
-            } else if(!this.allowFullConfiguration) {
+            } else if(!this.useConfigPrecisely) {
                 throw new Error(`Neither 'graphqlPort' nor process.env.PORT is set. ` +
                     `In order for Apollo Engine to act as a proxy for your GraphQL server, ` +
                     `it needs to know which port your GraphQL server is listening on (this is ` +
@@ -216,19 +216,31 @@ export class Engine extends EventEmitter {
         // Customize configuration:
         const childConfig = Object.assign({}, config as EngineConfig);
 
-        // Inject frontend, that we will route
+        // Inject frontend, that we will route for users that are allowing us to
+        // use the default configurations (i.e. users that have not set useConfigPrecisely
+        // to true)
         const frontend = Object.assign({
             host: '127.0.0.1',
             endpoints: [endpoint],
             port: 0,
         }, this.frontendParams);
         if (typeof childConfig.frontends === 'undefined') {
+            if (this.useConfigPrecisely) {
+                throw new Error(`Cannot run Apollo Engine with no frontend. Either specify ` +
+                    `at least one frontend in your engine-config or set useConfigPrecisely ` +
+                    `to false.`);
+            }
             childConfig.frontends = [frontend];
-        } else if (!this.allowFullConfiguration) {
+        } else if (!this.useConfigPrecisely) {
             childConfig.frontends.push(frontend)
         }
 
         if (typeof childConfig.origins === 'undefined') {
+            if (this.useConfigPrecisely) {
+                throw new Error(`Cannot run Apollo Engine with no origin. Either specify ` +
+                    `at least one origin in your engine-config or set useConfigPrecisely ` +
+                    `to false.`);
+            }
             const origin = Object.assign({}, this.originParams) as OriginConfig;
             const defaultHttpOrigin = {
                 url: 'http://127.0.0.1:' + graphqlPort + endpoint,
@@ -240,7 +252,7 @@ export class Engine extends EventEmitter {
                 origin.http = Object.assign({}, defaultHttpOrigin, origin.http);
             }
             childConfig.origins = [origin];
-        } else if(!this.allowFullConfiguration) {
+        } else if(!this.useConfigPrecisely) {
             // Extend any existing HTTP origins with the chosen PSK:
             // (trust it to fill other fields correctly)
             childConfig.origins.forEach(origin => {
@@ -306,6 +318,7 @@ export class Engine extends EventEmitter {
                 if (listeningAddress !== '') {
                     this.middlewareParams.uri = `http://${listeningAddress}`;
                     // Notify that proxy has started.
+                    console.log('STARTING ENGINE PROXY');
                     this.emit('start');
                 }
             });

--- a/test/engine.js
+++ b/test/engine.js
@@ -124,7 +124,7 @@ describe('engine', () => {
       }).listen(0);
     });
 
-    it('can be configured in single proxy mode', async () => {
+    it.only('can be configured in single proxy mode', async () => {
       // When using singleProxy the middleware is not required
       let port = gqlServer('/graphql');
 

--- a/test/engine.js
+++ b/test/engine.js
@@ -124,7 +124,7 @@ describe('engine', () => {
       }).listen(0);
     });
 
-    it.only('can be configured in single proxy mode', async () => {
+    it('can be configured in single proxy mode', async () => {
       // When using singleProxy the middleware is not required
       let port = gqlServer('/graphql');
 
@@ -146,7 +146,7 @@ describe('engine', () => {
       let testPort = gqlServer('/test/graphql');
       let defaultPort = gqlServer('/graphql');
       engine = new Engine({
-        allowFullConfiguration: true,
+        useConfigPrecisely: true,
         engineConfig: {
           apiKey: 'faked',
           origins: [

--- a/test/engine.json
+++ b/test/engine.json
@@ -1,5 +1,8 @@
 {
   "apiKey": "faked",
+  "reporting": {
+    "disabled": true
+  },
   "logging": {
     "level": "WARN",
     "request": {

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,7 @@ exports.testEngine = (path) => {
   path = path || '/graphql';
 
   return new Engine({
-    endpoints: [path],
+    endpoint: path,
     engineConfig: {
       logging: {
         level: 'warn'

--- a/test/test.js
+++ b/test/test.js
@@ -4,7 +4,7 @@ exports.testEngine = (path) => {
   path = path || '/graphql';
 
   return new Engine({
-    endpoint: path,
+    endpoints: [path],
     engineConfig: {
       logging: {
         level: 'warn'


### PR DESCRIPTION
Updates the name of the 'allowFullConfiguration' field to be 'useConfigPrecisely' and changes the logic to follow suit. We will no longer inject a frontend or origin, but error in the event that one is not specified and configuration calls for using precise engine-config.

This does _not_ change the endoint -> endpoints in SideloadConfig, but that'll be in a different PR soon (the logic is kinda meh with all the regex matching, but I have the work mostly done on a different branch)