### PR TITLE
Cease usage of top-level `await` in `README.md`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ const engine = new Engine({ engineConfig: { ... } });
 // create new engine instance from file
 const engine = new Engine({ engineConfig: 'path/to/config.json' });
 
-await engine.start();
+engine.start();
 app.use(engine.expressMiddleware());
 
 // ...


### PR DESCRIPTION
While top-level `await` is supported in some client environments (Google
Chrome, for example) I'm not aware of any server implementations that
currently support it (barring code-transformations which wrap it in an
`async` IIFE) and any such implementations are far from being a recommended
or best-practice.

It's not in our best interest, for adoption, to recommend this in the `README`.