### PR TITLE
Compile target set to es5 and Readme note about supporting Node 4 and above

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,13 @@ node_js:
   - "8"
   - "9"
 
-cache:
-  directories:
-    - $HOME/.npm
-    - node_modules
+# cache:
+#   directories:
+#     - $HOME/.npm
+#     - node_modules
 
 install:
-  - npm prune
+  # - npm prune
   - npm install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: node_js
+
+# For now we definitely support 4/6/8 (LTS), but we'd love to learn about how we
+# fare with newer versions too.
 node_js:
+  - "4"
+  - "6"
   - "8"
+  - "9"
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -5,12 +5,27 @@
 
 This package integrates the Apollo Engine Proxy with your GraphQL server.
 
-Read the docs at https://apollographql.com/docs/engine/setup-node.html
+Please read the [Asking for Help](#asking-for-help-and-filing-issues) section before opening an issue on this repository.
+
+## Installation
+
+Run the following command to install Apollo Engine:
+
+`npm install apollo-engine --save`
+
+> Note: Please use Node 4 or higher
+
+## Documentation
+
+To get started, read the [setup guide](https://apollographql.com/docs/engine/setup-node.html).
 
 Release notes for this package are at https://www.apollographql.com/docs/engine/proxy-release-notes.html
+
+## Asking for Help and Filing Issues
 
 For feature requests, bug reports, or general questions or feedback on Apollo Engine Proxy, please use [this form](https://engine.apollographql.com/login?overlay=SupportRequestNoAccount) instead of opening an issue on this repository.
 
 Because this repo contains a wrapper around the Apollo Engine Proxy binary, feature requests and support cases for the underlying proxy will be closed. Please only open an issue in this repo if you believe there is an issue with the wrapper/middleware code or if you would like a feature represented in the wrapper itself.
 
 For all other requests or questions, we encourage you to [use this form](https://engine.apollographql.com/login?overlay=SupportRequestNoAccount). The #engine channel in the [Apollo Slack](apollographql.com/#slack) can also be a great resource for general questions about Apollo Engine. Following these guidelines will ensure that your requests are seen and addressed as quickly as possible and also allows us to better collect and iterate on feedback.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -7079,9 +7079,9 @@
       }
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "tmp": "0.0.33",
     "ts-jest": "^22.4.1",
     "tslint": "^5.8.0",
-    "typescript": "^2.4.1"
+    "typescript": "^2.7.2"
   },
   "prettier": {
     "trailingComma": "all",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/restify": "^5.0.7"
   },
   "devDependencies": {
+    "@types/body-parser": "^1.16.8",
     "@types/graphql": "^0.9.2",
     "@types/hapi": "^17.0.4",
     "@types/jest": "^22.1.4",

--- a/src/__tests__/engine-common.ts
+++ b/src/__tests__/engine-common.ts
@@ -150,7 +150,7 @@ export function runSuitesForHttpServerFramework(
                 [appParameter]: app,
               },
               () => {
-                resolve(`${engine!.engineListeningAddress.url}/graphql`);
+                resolve(`${engine!.engineListeningAddress!.url}/graphql`);
               },
             );
           });

--- a/src/__tests__/engine.test.ts
+++ b/src/__tests__/engine.test.ts
@@ -65,7 +65,7 @@ function connectQuery(
   next: Function,
 ) {
   const parsedUrl = urlModule.parse(req.url!);
-  (req as any).query = qs.parse(parsedUrl.query);
+  (req as any).query = qs.parse(parsedUrl.query!);
   next();
 }
 

--- a/src/__tests__/engine.test.ts
+++ b/src/__tests__/engine.test.ts
@@ -232,7 +232,7 @@ describe('hapi integration', () => {
         });
         await gqlServer({ autoListen: false, listener: hapiListener });
         await server.start();
-        return `${engine.engineListeningAddress.url}/graphql`;
+        return `${engine.engineListeningAddress!.url}/graphql`;
       },
       false,
       'hapi',

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -35,11 +35,11 @@ export interface HapiListenOptions extends CoreListenOptions {}
 // Node web framework of choice.
 export class ApolloEngine extends EventEmitter {
   // Primarily useful if you're having engine listen on 0 for tests.
-  public engineListeningAddress: ListeningAddress;
+  public engineListeningAddress?: ListeningAddress;
 
   private config: EngineConfig;
   private launcher: ApolloEngineLauncher;
-  private httpServer: HttpServer;
+  private httpServer: HttpServer | null;
 
   // The constructor takes the underlying engineproxy config file. All options
   // specific to the Node API are passed to `listen` (or other entry point) to
@@ -48,6 +48,7 @@ export class ApolloEngine extends EventEmitter {
     super();
     this.config = config;
     this.launcher = new ApolloEngineLauncher(config);
+    this.httpServer = null;
   }
 
   // listen tells your app to listen on an ephemeral port, then starts an
@@ -120,7 +121,8 @@ export class ApolloEngine extends EventEmitter {
   public async stop() {
     await this.launcher.stop();
     // XXX Should we also wait for all current connections to be closed?
-    this.httpServer.close();
+    this.httpServer!.close();
+    this.httpServer = null;
   }
 
   // Call this from the top level of a Meteor server as

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -24,6 +24,7 @@ export class ApolloEngineLauncher extends EventEmitter {
     super();
 
     this.config = config;
+    this.child = null;
     switch (process.platform) {
       case 'darwin':
         this.binary = require.resolve(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2015",
+    "target": "es5",
     "module": "commonjs",
     "moduleResolution": "node",
     "declaration": true,


### PR DESCRIPTION
The target of `tsc` should be es5, so that Node 4 is supported. Currently my use case, webtasks in [launchpad](https://github.com/apollographql/launchpad), still uses Node 4, which is on LTS for a little while. Also added a note about the Node version in the README with some additional section headers.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [x] feature
- [x] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->