### PR TITLE
Deal with https server type

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -1,6 +1,7 @@
 import { ListenOptions as NetListenOptions } from 'net';
 import { EventEmitter } from 'events';
 import { Server as HttpServer } from 'http';
+import { Server as HttpsServer } from 'https';
 
 import { Application as ExpressApp } from 'express';
 import { Server as ConnectApp } from 'connect';
@@ -22,7 +23,7 @@ export interface CoreListenOptions extends MeteorListenOptions {
 }
 
 export interface ListenOptions extends CoreListenOptions {
-  httpServer?: HttpServer;
+  httpServer?: HttpServer | HttpsServer;
   expressApp?: ExpressApp;
   connectApp?: ConnectApp;
   koaApp?: KoaApp;


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] has-reproduction
- [x] feature
- [ ] blocking
- [x] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Simple typing add to deal with `HttpsServer`, it's to avoid a manual typing into `graphql-yoga` futur implementation (cf https://github.com/graphcool/graphql-yoga/pull/209)