### PR TITLE
Run tests in Node.js 4, 6, 8 and 9 by switching to CircleCI workflows.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,31 +1,94 @@
 version: 2
+#
+# Reusable Snippets!
+#
+# These are re-used by the various tests below, to avoid repetition.
+#
+run_install_desired_npm: &run_install_desired_npm
+  run:
+    # Due to a bug, npm upgrades from the version of npm that ships with
+    # Node.js 6 (npm v3.10.10) go poorly and generally cause other problems
+    # within the environment.  Since `yarn` is already available here we can
+    # use that to work-around the issue.  It's possible that `npm` artifact
+    # jockeying might avoid this need, but this can be removed once Node 6 is
+    # no longer being built below.
+    name: Install npm@latest, but with yarn.
+    command: sudo yarn global add npm@latest
+
+# These are the steps used for each version of Node which we're testing
+# against.  Thanks to YAMLs inability to merge arrays (though it is able
+# to merge objects), every version of Node must use the exact same steps,
+# or these steps would need to be repeated in a version of Node that needs
+# something different.  Probably best to avoid that, out of principle, though.
+common_test_steps: &common_test_steps
+  steps:
+    # Install the latest npm, rather than using the versions which ship
+    # in older versions of Node.js  This allows for a more consistent
+    # installation, and typically users of older Node versions at least
+    # update their npm to the latest.
+    - *run_install_desired_npm
+
+    - checkout
+
+    # Download and cache dependencies
+    - restore_cache:
+        keys:
+        - v1-dependencies-{{ checksum "package-lock.json" }}
+        # fallback to using the latest cache if no exact match is found
+        - v1-dependencies-
+
+    - run: node --version
+
+    - run: npm --version
+
+    - run: npm install
+
+    - save_cache:
+        paths:
+          - node_modules
+        key: v1-dependencies-{{ checksum "package-lock.json" }}
+
+    # test with coverage.
+    - run: npm run circle
+
+
 jobs:
-  build:
-    docker:
-      # specify the version you desire here
-      - image: circleci/node:8
+  # Platform tests, each with the same tests but different platform or version.
+  # The docker tag represents the Node.js version and the full list is available
+  # at https://hub.docker.com/r/circleci/node/.
+  Node.js 4:
+    docker: [ { image: 'circleci/node:4' } ]
+    <<: *common_test_steps
 
+  Node.js 6:
+    docker: [ { image: 'circleci/node:6' } ]
+    <<: *common_test_steps
+
+  Node.js 8:
+    docker: [ { image: 'circleci/node:8' } ]
+    <<: *common_test_steps
+
+  # This should be replaced with Node 10, when released in ~April 2018.
+  Node.js 9:
+    docker: [ { image: 'circleci/node:9' } ]
+    <<: *common_test_steps
+
+  # Linting can run on the latest Node, which already has the latest `npm` and
+  # doesn't warrant run_install_desired_npm (which is more critical above)
+  Linting:
+    docker: [ { image: 'circleci/node:8' } ]
     steps:
+      # (speed) Intentionally omitted (unnecessary) run_install_desired_npm.
       - checkout
-
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-          - v1-dependencies-{{ checksum "package-lock.json" }}
-          # fallback to using the latest cache if no exact match is found
-          - v1-dependencies-
-
-      - run: npm --version
-
       - run: npm install
-
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dependencies-{{ checksum "package-lock.json" }}
-
       - run: npm run lint
 
-      # test with coverage.
-      - run: npm run circle
-
+workflows:
+  version: 2
+  Build and Test:
+    jobs:
+      - Node.js 4
+      - Node.js 6
+      - Node.js 8
+      - Node.js 9
+      - Linting


### PR DESCRIPTION
This aims to accomplish the request @glasser made in #161, which I came
across while reviewing docs PRs.

My recommendation is that the original intention of @evans PR should be broken
out into its own commit/PR which only changes the `target` transpilation
language to `es5`, after (and of course, "if") this PR has landed.

I expect the results of this commit's first test-run on CircleCI to support
the original need for #161 by showing a failure on Node.js 4, though I
wouldn't be entirely surprised to see failures on  Node.js 6 either.

Ref: https://github.com/apollographql/apollo-engine-js/pull/161#pullrequestreview-105205818